### PR TITLE
Fix default recipe duplication and cleanup

### DIFF
--- a/app/RecipeCloudStore.swift
+++ b/app/RecipeCloudStore.swift
@@ -219,6 +219,40 @@ class RecipeCloudStore {
         }
     }
 
+    /// Delete multiple recipes from Firestore by their document IDs
+    func deleteRecipes(ids: [String]) {
+        guard let _ = currentUID, !ids.isEmpty else { return }
+        let batch = db.batch()
+        ids.forEach { id in
+            let ref = db.collection("recipes").document(id)
+            batch.deleteDocument(ref)
+        }
+        batch.commit { error in
+            if let error = error {
+                print("❌ Failed to delete duplicate recipes: \(error)")
+            } else {
+                print("🗑️ Deleted \(ids.count) duplicate recipes")
+            }
+        }
+    }
+
+    /// Delete multiple collections from Firestore by their document IDs
+    func deleteCollections(ids: [String]) {
+        guard let _ = currentUID, !ids.isEmpty else { return }
+        let batch = db.batch()
+        ids.forEach { id in
+            let ref = db.collection("collections").document(id)
+            batch.deleteDocument(ref)
+        }
+        batch.commit { error in
+            if let error = error {
+                print("❌ Failed to delete duplicate collections: \(error)")
+            } else {
+                print("🗑️ Deleted \(ids.count) duplicate collections")
+            }
+        }
+    }
+
     // ========================================================================
     // MARK: - 👤 User Profile (The Important Stuff You Actually Use)
     // ========================================================================


### PR DESCRIPTION
## Summary
- avoid loading sample recipes for authenticated users
- deduplicate recipes and collections when loading from Firestore and remove duplicates from the server
- add Firestore helpers to delete recipe and collection documents

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swiftc -typecheck app/ContentView.swift` *(fails: no such module 'SwiftUI')*
- `swiftc -typecheck app/RecipeCloudStore.swift` *(fails: no such module 'FirebaseFirestore')*


------
https://chatgpt.com/codex/tasks/task_e_68920b6d2ee083319422618ea0a1c4f1