### PR TITLE
Enable long-press removal of recipes from collections

### DIFF
--- a/app/ContentView.swift
+++ b/app/ContentView.swift
@@ -2220,6 +2220,12 @@ struct CollectionDetailView: View {
                     NavigationLink(destination: RecipeDetailView(recipe: recipe)) {
                         RecipeCard(recipe: recipe)
                             .contentShape(Rectangle())
+                            .onLongPressGesture(minimumDuration: 0.5) {
+                                UINotificationFeedbackGenerator().notificationOccurred(.success)
+                                withAnimation {
+                                    store.toggle(recipe, in: collection)
+                                }
+                            }
                     }
                     .buttonStyle(.plain)
                 }


### PR DESCRIPTION
## Summary
- allow long pressing recipes in a collection to remove them with haptic feedback

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68920fe352cc833198f8429a74274f42